### PR TITLE
Avoid React warning when rendering list

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -18359,24 +18359,24 @@ module.exports = React.createClass({displayName: "exports",
         };
     },
 
-    _getListItemClass: function(item, height) {
+    _getListItemClass: function(item, height, key) {
         if (this.props.listItemClass) {
-            return React.createElement(this.props.listItemClass, {item: item, height: height});
+            return React.createElement(this.props.listItemClass, {item: item, height: height, key: key});
         }
 
-        return React.createElement(InfiniteListItem, {item: item, height: height});
+        return React.createElement(InfiniteListItem, {item: item, height: height, key: key});
     },
 
     render: function() {
-        var itemsToRender = {};
+        var itemsToRender = [];
 
-        itemsToRender['top'] = (React.createElement("div", {className: "topitem", 
-            style: {height: this.state.renderedStart * this.props.itemHeight}}));
+        itemsToRender.push(React.createElement("div", {className: "topitem", 
+            style: {height: this.state.renderedStart * this.props.itemHeight}, key: "top"}));
 
         for (var i = this.state.renderedStart; i <= this.state.renderedEnd; i++) {
             var item = this.props.items[i];
-            itemsToRender['item ' + i] = this._getListItemClass(item,
-                this.props.itemHeight);
+            itemsToRender.push(this._getListItemClass(item,
+                this.props.itemHeight, 'item ' + i));
         }
 
         return (
@@ -18390,6 +18390,7 @@ module.exports = React.createClass({displayName: "exports",
         );
     }
 });
+
 },{"react":"react"}],"react":[function(require,module,exports){
 module.exports = require('./lib/React');
 

--- a/dist/infinite_list.js
+++ b/dist/infinite_list.js
@@ -46,24 +46,24 @@ module.exports = React.createClass({displayName: "exports",
         };
     },
 
-    _getListItemClass: function(item, height) {
+    _getListItemClass: function(item, height, key) {
         if (this.props.listItemClass) {
-            return React.createElement(this.props.listItemClass, {item: item, height: height});
+            return React.createElement(this.props.listItemClass, {item: item, height: height, key: key});
         }
 
-        return React.createElement(InfiniteListItem, {item: item, height: height});
+        return React.createElement(InfiniteListItem, {item: item, height: height, key: key});
     },
 
     render: function() {
-        var itemsToRender = {};
+        var itemsToRender = [];
 
-        itemsToRender['top'] = (React.createElement("div", {className: "topitem", 
-            style: {height: this.state.renderedStart * this.props.itemHeight}}));
+        itemsToRender.push(React.createElement("div", {className: "topitem", 
+            style: {height: this.state.renderedStart * this.props.itemHeight}, key: "top"}));
 
         for (var i = this.state.renderedStart; i <= this.state.renderedEnd; i++) {
             var item = this.props.items[i];
-            itemsToRender['item ' + i] = this._getListItemClass(item,
-                this.props.itemHeight);
+            itemsToRender.push(this._getListItemClass(item,
+                this.props.itemHeight, 'item ' + i));
         }
 
         return (
@@ -77,5 +77,6 @@ module.exports = React.createClass({displayName: "exports",
         );
     }
 });
+
 },{"react":"react"}]},{},[1])(1)
 });

--- a/src/infinite_list.js
+++ b/src/infinite_list.js
@@ -45,24 +45,24 @@ module.exports = React.createClass({
         };
     },
 
-    _getListItemClass: function(item, height) {
+    _getListItemClass: function(item, height, key) {
         if (this.props.listItemClass) {
-            return <this.props.listItemClass item={item} height={height}/>;
+            return <this.props.listItemClass item={item} height={height} key={key}/>;
         }
 
-        return <InfiniteListItem item={item} height={height}/>;
+        return <InfiniteListItem item={item} height={height} key={key}/>;
     },
 
     render: function() {
-        var itemsToRender = {};
+        var itemsToRender = [];
 
-        itemsToRender['top'] = (<div className="topitem"
-            style={{height: this.state.renderedStart * this.props.itemHeight}} />);
+        itemsToRender.push(<div className="topitem"
+            style={{height: this.state.renderedStart * this.props.itemHeight}} key="top" />);
 
         for (var i = this.state.renderedStart; i <= this.state.renderedEnd; i++) {
             var item = this.props.items[i];
-            itemsToRender['item ' + i] = this._getListItemClass(item,
-                this.props.itemHeight);
+            itemsToRender.push(this._getListItemClass(item,
+                this.props.itemHeight, 'item ' + i));
         }
 
         return (


### PR DESCRIPTION
Avoid "Warning: Any use of a keyed object should be wrapped in
React.addons.createFragment(object) before being passed as a child."