### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "email": "jan.kopriva@email.cz",
     "url": "https://github.com/jankopriva/"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jankopriva/react-infinite-list.git"
+  },
   "devDependencies": {
     "autoprefixer-loader": "1.1.0",
     "babel": "^5.4.7",


### PR DESCRIPTION
Adding the repository to package.json lets you navigate to it from the npmjs.com web app