### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "email": "jan.kopriva@email.cz",
     "url": "https://github.com/jankopriva/"
   },
+  "license": "MIT",
   "devDependencies": {
     "autoprefixer-loader": "1.1.0",
     "babel": "^5.4.7",


### PR DESCRIPTION
Adding license to package.json will remove the npm warning when installing
It also allows users to filter out packages they can't use in their organization

I added `"license": "MIT"` since that's what's in your `bower.json` file as well. 